### PR TITLE
Add Engineering Manager Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,7 @@
 | [progression.fyi](https://progression.fyi/) | Career framework inspiration from the world's best companies. |
 | [levels.fyi](http://levels.fyi/) | Compensations at various levels |
 | [roadmaps.sh](https://roadmap.sh/) | Engineering career roadmaps |
+| [AI Interview Coach](https://em-tools.io/interview-prep) | Voice-based AI behavioral interview practice for engineering managers and software engineers |
 
 ## Related Awesome Lists
 

--- a/README.md
+++ b/README.md
@@ -653,6 +653,7 @@
 | [levels.fyi](http://levels.fyi/) | Compensations at various levels |
 | [roadmaps.sh](https://roadmap.sh/) | Engineering career roadmaps |
 | [AI Interview Coach](https://em-tools.io/interview-prep) | Voice-based AI behavioral interview practice for engineering managers and software engineers |
+| [Blog for Engineering Managers](https://blog4ems.com) | Practical guidance, templates, and resources for engineering managers |
 
 ## Related Awesome Lists
 


### PR DESCRIPTION
## Add Engineering Manager Resources

### AI Interview Coach
[AI Interview Coach](https://em-tools.io/interview-prep) - Voice-based AI behavioral interview practice built for software engineers and engineering managers. 130+ role-specific questions, STAR-format scoring across 6 dimensions, probing follow-ups, and 3 interviewer personas (Startup CTO, Big Tech VP, Scale-up Director). Free first question.

### Blog for Engineering Managers
[Blog for Engineering Managers](https://blog4ems.com) - Practical guidance, templates, and resources for engineering managers. Weekly newsletter covering hiring, talent management, team execution, and leadership development. 50+ Notion templates and an Engineering Manager's Field Guide.